### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,16 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
-* `OpenSSLDialer` type to use SSL transport for `tarantool/go-tarantool/v2`
-  connection (#1).
-
 ### Changed
 
-### Removed
-
 ### Fixed
+
+## [1.0.0] - 2024-02-12
+
+The first release of the library allows us to extract the dependency on
+OpenSSL from the connector [go-tarantool](https://pkg.go.dev/github.com/tarantool/go-tarantool/v2).
+
+### Added
+
+* `OpenSSLDialer` type to use SSL transport for `tarantool/go-tarantool/v2`
+  connection (#1).

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/tarantool/go-iproto v1.0.0
 	github.com/tarantool/go-openssl v1.0.0
-	github.com/tarantool/go-tarantool/v2 v2.0.0-20240208121257-f33032e7d0ac
+	github.com/tarantool/go-tarantool/v2 v2.0.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/tarantool/go-iproto v1.0.0 h1:quC4hdFhCuFYaCqOFgUxH2foRkhAy+TlEy7gQLh
 github.com/tarantool/go-iproto v1.0.0/go.mod h1:LNCtdyZxojUed8SbOiYHoc3v9NvaZTB7p96hUySMlIo=
 github.com/tarantool/go-openssl v1.0.0 h1:kE0XhXi8b1qWOLwmcasAS67OyQdGXn42t0Qv3NwEjWY=
 github.com/tarantool/go-openssl v1.0.0/go.mod h1:M7H4xYSbzqpW/ZRBMyH0eyqQBsnhAMfsYk5mv0yid7A=
-github.com/tarantool/go-tarantool/v2 v2.0.0-20240208121257-f33032e7d0ac h1:5yuBAXF4W++mVj2Vcc99zgwdfgLSzyWrQmj/umDLFB4=
-github.com/tarantool/go-tarantool/v2 v2.0.0-20240208121257-f33032e7d0ac/go.mod h1:fBXE0XRt/jiAoDdk2zMQzkNQOWrVnz3rfscIhgRPFqA=
+github.com/tarantool/go-tarantool/v2 v2.0.0 h1:1Zl9d5JgVn3a69G2NqmQU0PFUfaWfJV9imXNzsNnXHs=
+github.com/tarantool/go-tarantool/v2 v2.0.0/go.mod h1:cpjGW5FHAXIMf0PKZte70pMOeadw1MA/hrDv1LblWk4=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=


### PR DESCRIPTION
## Overview

The first release of the library allows us to extract the dependency on OpenSSL from the connector [go-tarantool](https://pkg.go.dev/github.com/tarantool/go-tarantool/v2).

## New features

* `OpenSSLDialer` type to use SSL transport for `tarantool/go-tarantool/v2` connection (#1).