### PR TITLE
Release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,15 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ## Changed
 
-- Bump go-openssl to v1.2.1.
-
 ## Fixed
+
+## [v1.0.2] - 2025-01-27
+
+The release fixes tests on Tarantool Cluster Manager.
+
+## Changed
+
+- Bump go-openssl to v1.2.1.
 
 ## [v1.0.1] - 2025-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ## Changed
 
+- Bump go-openssl to v1.2.1.
+
 ## Fixed
 
 ## [v1.0.1] - 2025-01-23

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/tarantool/go-tlsdialer
 
 require (
-	github.com/stretchr/testify v1.11.1
+	github.com/stretchr/testify v1.10.0
 	github.com/tarantool/go-iproto v1.0.0
-	github.com/tarantool/go-openssl v1.2.0
+	github.com/tarantool/go-openssl v1.2.1
 	github.com/tarantool/go-tarantool/v2 v2.0.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -15,12 +15,12 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tarantool/go-iproto v1.0.0 h1:quC4hdFhCuFYaCqOFgUxH2foRkhAy+TlEy7gQLhdVjw=
 github.com/tarantool/go-iproto v1.0.0/go.mod h1:LNCtdyZxojUed8SbOiYHoc3v9NvaZTB7p96hUySMlIo=
-github.com/tarantool/go-openssl v1.2.0 h1:Y1n/iCi56U3kR441KvHB7aFgvtZG0i3j5c55mlxrsNE=
-github.com/tarantool/go-openssl v1.2.0/go.mod h1:16Y5xWqbhLmzPDU/wT+M8rXKhGPAdtEkvQJqQzyhcKY=
+github.com/tarantool/go-openssl v1.2.1 h1:WUVTeEPuBAXbrBjvJZ3ynzk/Sv4DL47V/ehWea9czjA=
+github.com/tarantool/go-openssl v1.2.1/go.mod h1:EwX1pKIGypLxkY49vKIIR4LTT+94DhKiunCqU2gEzLQ=
 github.com/tarantool/go-tarantool/v2 v2.0.0 h1:1Zl9d5JgVn3a69G2NqmQU0PFUfaWfJV9imXNzsNnXHs=
 github.com/tarantool/go-tarantool/v2 v2.0.0/go.mod h1:cpjGW5FHAXIMf0PKZte70pMOeadw1MA/hrDv1LblWk4=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=


### PR DESCRIPTION
The release fixes tests on Tarantool Cluster Manager.

## Changed

- Bump go-openssl to v1.2.1.